### PR TITLE
Prevent greedy --used/executed from capturing file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
   # push:
   #   branches:
   #     - master

--- a/cwl/synapse-get-annotations-tool.cwl
+++ b/cwl/synapse-get-annotations-tool.cwl
@@ -20,7 +20,7 @@ s:author:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 inputs:
 

--- a/cwl/synapse-get-sts-tool.cwl
+++ b/cwl/synapse-get-sts-tool.cwl
@@ -19,7 +19,7 @@ s:author:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 inputs:
   - id: synapse_config

--- a/cwl/synapse-get-tool.cwl
+++ b/cwl/synapse-get-tool.cwl
@@ -17,7 +17,7 @@ s:author:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 inputs:
   - id: synapse_config

--- a/cwl/synapse-query-tool.cwl
+++ b/cwl/synapse-query-tool.cwl
@@ -16,7 +16,7 @@ s:author:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 requirements:
   - class: InitialWorkDirRequirement

--- a/cwl/synapse-set-annotations-tool.cwl
+++ b/cwl/synapse-set-annotations-tool.cwl
@@ -20,7 +20,7 @@ s:author:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 inputs:
 

--- a/cwl/synapse-store-tool.cwl
+++ b/cwl/synapse-store-tool.cwl
@@ -27,7 +27,7 @@ s:contributor:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
 
 inputs:
   - id: synapse_config

--- a/cwl/synapse-store-tool.cwl
+++ b/cwl/synapse-store-tool.cwl
@@ -61,6 +61,7 @@ arguments:
   - valueFrom: $(inputs.name)
     prefix: --name
   - valueFrom: $(inputs.file_to_store.path)
+    prefix: --
 
 stdout: stdout.txt
 

--- a/cwl/synapse-sync-to-synapse-tool.cwl
+++ b/cwl/synapse-sync-to-synapse-tool.cwl
@@ -23,7 +23,7 @@ s:contributor:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.1.1
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
     
 inputs:
   - id: synapse_config

--- a/tests/store/store_greedy_args.yaml
+++ b/tests/store/store_greedy_args.yaml
@@ -1,0 +1,9 @@
+parentid: syn22172371
+synapse_config:
+  class: File
+  path: '/tmp/.synapseConfig'
+file_to_store:
+  class: File
+  path: 'test.txt'
+used: [syn22172371, syn22172494]
+executed: [syn22172494]

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -45,16 +45,16 @@
 - job: store/store_greedy_args.yaml
   output:
     "stdout": {
-      "checksum": "sha1$dda791b2e6ca496820fdc708a9d27e88d7838170",
+      "checksum": "sha1$804a8d86547df5deb13d99a8899dc83bfadf290c",
       "class": "File",
       "location": "stdout.txt",
-      "size": 187
+      "size": 185
     }
-    "file_id": "syn22254267"
+    "file_id": "syn22172494"
   tool: ../cwl/synapse-store-tool.cwl
   label: synapse_store_greedy_arguments
   id: 3
-  doc: >
+  doc: >-
     Store file to Synapse where --used/--executed (which
     are greedy arguments) are the last optional arguments
 - job: query.yaml

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -42,6 +42,21 @@
   label: synapse_store
   id: 3
   doc: Store file to Synapse
+- job: store/store_greedy_args.yaml
+  output:
+    "stdout": {
+      "checksum": "sha1$dda791b2e6ca496820fdc708a9d27e88d7838170",
+      "class": "File",
+      "location": "stdout.txt",
+      "size": 187
+    }
+    "file_id": "syn22254267"
+  tool: ../cwl/synapse-store-tool.cwl
+  label: synapse_store_greedy_arguments
+  id: 3
+  doc: >
+    Store file to Synapse where --used/--executed (which
+    are greedy arguments) are the last optional arguments
 - job: query.yaml
   output:
     "query_result": {


### PR DESCRIPTION
I ran into an issue while trying to use the `--used` and `--executed` provenance arguments. Because of the way that `argparse` works in the synapse CLI client, they capture CLI values greedily, and this can cause the file positional argument to be captured by one of these two optional arguments. See error below, where the file path is being included in `--used`, leaving not file for the client to upload. 

```
$ synapse store --parentId syn22310623 --used syn22344112 syn22344113 syn22344114 workflow/examples/mutation_models.tsv  

SynapseHTTPError: 400 Client Error: 
FileEntity.dataFileHandleId cannot be null
```

The simple fix is to separate the optional and positional arguments with `--`, which is a UNIX convention that `argparse` adheres to. This ensures that the `--used` and `--executed` arguments don't capture the file positional argument. For example:

```
$ synapse store --parentId syn22310623 --used syn22344112 syn22344113 syn22344114 -- workflow/examples/mutation_models.tsv 

Created/Updated entity: syn22344757     mutation_models.tsv
```

This can be achieved with a simple one-line fix in the CWL tool, as shown in this PR. I was able to test this fix in another project and can confirm that it solved the error I was previously running into. 

If this is merged, can v1.1 be minted?