### PR TITLE
Prevent greedy --used/executed from capturing file (take 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
   # push:
   #   branches:
   #     - master

--- a/cwl/synapse-store-tool.cwl
+++ b/cwl/synapse-store-tool.cwl
@@ -61,6 +61,7 @@ arguments:
   - valueFrom: $(inputs.name)
     prefix: --name
   - valueFrom: $(inputs.file_to_store.path)
+    prefix: --
 
 stdout: stdout.txt
 

--- a/tests/store/store_greedy_args.yaml
+++ b/tests/store/store_greedy_args.yaml
@@ -1,0 +1,9 @@
+parentid: syn22172371
+synapse_config:
+  class: File
+  path: '/tmp/.synapseConfig'
+file_to_store:
+  class: File
+  path: 'test.txt'
+used: [syn22172371, syn22172494]
+executed: [syn22172494]

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -45,16 +45,16 @@
 - job: store/store_greedy_args.yaml
   output:
     "stdout": {
-      "checksum": "sha1$dda791b2e6ca496820fdc708a9d27e88d7838170",
+      "checksum": "sha1$804a8d86547df5deb13d99a8899dc83bfadf290c",
       "class": "File",
       "location": "stdout.txt",
-      "size": 187
+      "size": 185
     }
-    "file_id": "syn22254267"
+    "file_id": "syn22172494"
   tool: ../cwl/synapse-store-tool.cwl
   label: synapse_store_greedy_arguments
   id: 3
-  doc: >
+  doc: >-
     Store file to Synapse where --used/--executed (which
     are greedy arguments) are the last optional arguments
 - job: query.yaml

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -42,6 +42,21 @@
   label: synapse_store
   id: 3
   doc: Store file to Synapse
+- job: store/store_greedy_args.yaml
+  output:
+    "stdout": {
+      "checksum": "sha1$dda791b2e6ca496820fdc708a9d27e88d7838170",
+      "class": "File",
+      "location": "stdout.txt",
+      "size": 187
+    }
+    "file_id": "syn22254267"
+  tool: ../cwl/synapse-store-tool.cwl
+  label: synapse_store_greedy_arguments
+  id: 3
+  doc: >
+    Store file to Synapse where --used/--executed (which
+    are greedy arguments) are the last optional arguments
 - job: query.yaml
   output:
     "query_result": {


### PR DESCRIPTION
This PR contains the same code as #30, but it's being made from a local branch rather than a forked repository. This is an attempt to make the testing framework work given that the Synapse credentials are stored as GitHub secrets on this repo rather than in my fork. Let's see if the tests work! 