### PR TITLE
Add Synapse create tool with test case

### DIFF
--- a/cwl/synapse-create-tool.cwl
+++ b/cwl/synapse-create-tool.cwl
@@ -1,0 +1,82 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+id: "synapse-create"
+label: "Synapse command line client subcommand for creating a project/folder."
+
+baseCommand: 
+  - synapse
+  - create
+
+$namespaces:
+  s: https://schema.org/
+
+s:author:
+  - class: s:Person
+    s:identifier: https://orcid.org/0000-0002-4621-1589
+    s:email: bruno.grande@sagebase.org
+    s:name: Bruno Grande
+
+hints:
+  DockerRequirement:
+    dockerPull: sagebionetworks/synapsepythonclient:v2.2.0
+
+inputs:
+  - id: synapse_config
+    type: File
+  - id: parentid
+    type: string?
+    inputBinding:
+      prefix: --parentId
+  - id: name
+    type: string
+    inputBinding:
+      prefix: --name
+  - id: description
+    type: string?
+    inputBinding:
+      prefix: --description
+  - id: description_file
+    type: File?
+    inputBinding:
+      prefix: --descriptionFile
+  - id: type
+    type:
+      type: enum
+      symbols: [Project, Folder]
+    inputBinding:
+      position: 2
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: .synapseConfig
+        entry: $(inputs.synapse_config)
+
+stdout: stdout.txt
+
+outputs:
+  - id: stdout
+    type: File
+    outputBinding:
+      glob: stdout.txt
+  - id: file_id
+    type: string
+    outputBinding:
+      glob: stdout.txt
+      loadContents: true
+      outputEval: $(self[0].contents.split("\n")[0].split(/(\s+)/)[4])
+
+# Example command and output of synapse create:
+#
+#   $ synapse create -parentId syn23344520 -name testDir Folder
+#   Created entity: syn23416766	testDir
+#
+# Steps to access the Synapse ID
+#
+#   1. Access line 1: "contents.split("\n")[0]"
+#   2. Split by whitespace: ".split(/(\s+)/)"
+#   3. Access the the 5th item: "[4]"

--- a/tests/create.yaml
+++ b/tests/create.yaml
@@ -1,0 +1,8 @@
+synapse_config:
+  class: File
+  path: '/tmp/.synapseConfig'
+
+parentid: syn22172371
+type: Folder
+name: mydirectory
+description: The best test directory there ever was

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -53,10 +53,23 @@
     "file_id": "syn22172494"
   tool: ../cwl/synapse-store-tool.cwl
   label: synapse_store_greedy_arguments
-  id: 3
+  id: 4
   doc: >-
     Store file to Synapse where --used/--executed (which
     are greedy arguments) are the last optional arguments
+- job: create.yaml
+  output:
+    "stdout": {
+      "checksum": "sha1$1c35108ee957a953f9071b40eb9b874e4ffe64cd",
+      "class": "File",
+      "location": "stdout.txt",
+      "size": 41
+    }
+    "file_id": "syn23419632"
+  tool: ../cwl/synapse-create-tool.cwl
+  label: synapse_create
+  id: 5
+  doc: Create a folder on Synapse
 - job: query.yaml
   output:
     "query_result": {
@@ -67,13 +80,13 @@
     }
   tool: ../cwl/synapse-query-tool.cwl
   label: synapse_query
-  id: 4
+  id: 6
   doc: Query a table or file view in Synapse
 - job: sync/sync.yaml
   output: {}
   tool: ../cwl/synapse-sync-to-synapse-tool.cwl
   label: synapse_sync
-  id: 5
+  id: 7
   doc: Sync files into Synapse with a manifest
 - job: get-sts-token.yaml
   output:
@@ -88,5 +101,5 @@
     "basekey": Any
   tool: ../cwl/synapse-get-sts-tool.cwl
   label: synapse_get_sts
-  id: 6
+  id: 8
   doc: Get Synapse STS token


### PR DESCRIPTION
I needed a CWL tool for creating folders on Synapse. This is that tool. I included a test case using the Synapse service account, which passes locally. 

```
$ cwltest --test tests/test-descriptions.yaml --tool cwltool

Test [1/9] synapse_get_annotations: Get annotations
Test [2/9] synapse_set_annotations: Set annotations
Test [3/9] synapse_get: Get synapse file
Test [4/9] synapse_store: Store file to Synapse
Test [5/9] synapse_store_greedy_arguments: Store file to Synapse where --used/--executed (which are greedy arguments) are the last optional arguments
Test [6/9] synapse_create: Create a folder on Synapse
Test [7/9] synapse_query: Query a table or file view in Synapse
Test [8/9] synapse_sync: Sync files into Synapse with a manifest
Test [9/9] synapse_get_sts: Get Synapse STS token
All tests passed
```

I'm using this in another workflow, so once this is merged, I could appreciate a new version. Thanks!

(Duplicate of #33, but from a branch within the repo rather than from a fork in an attempt to overcome persistent CI [issues](https://github.com/Sage-Bionetworks-Workflows/dockstore-tool-synapseclient/pull/33/checks?check_run_id=1350228792).) 